### PR TITLE
read data from stdin or from file and fix CVE-2017-2809

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,19 +17,19 @@ install:
 script:
   - tox
   - python setup.py install
-  - niet tests/samples/sample.yaml project.meta.name
-  - niet tests/samples/sample.yaml .project.meta.name
-  - niet tests/samples/sample.yaml project.list-items
-  - niet tests/samples/sample.json .project.list-items
-  - niet tests/samples/sample.json .
-  - niet -f squote tests/samples/sample.yaml project.list-items
-  - niet -f squote tests/samples/sample.yaml project.meta.name
-  - niet -f dquote tests/samples/sample.yaml project.list-items
-  - niet -f dquote tests/samples/sample.yaml project.meta.name
-  - niet -f ifs tests/samples/sample.yaml project.list-items
-  - niet --format newline tests/samples/sample.yaml project.list-items
-  - niet --format yaml tests/samples/sample.yaml project.list-items
-  - niet --format json tests/samples/sample.yaml project.list-items
+  - niet project.meta.name tests/samples/sample.yaml
+  - niet .project.meta.name tests/samples/sample.yaml
+  - niet project.list-items tests/samples/sample.yaml
+  - niet .project.list-items tests/samples/sample.json
+  - niet . tests/samples/sample.json
+  - niet -f squote project.list-items tests/samples/sample.yaml
+  - niet -f squote project.meta.name tests/samples/sample.yaml
+  - niet -f dquote project.list-items tests/samples/sample.yaml
+  - niet -f dquote project.meta.name tests/samples/sample.yaml
+  - niet -f ifs project.list-items tests/samples/sample.yaml
+  - niet --format newline project.list-items tests/samples/sample.yaml
+  - niet --format yaml project.list-items tests/samples/sample.yaml
+  - niet --format json project.list-items tests/samples/sample.yaml
 
 deploy:
   - provider: pypi
@@ -39,12 +39,3 @@ deploy:
     on:
       tags: true
     distributions: sdist bdist_wheel
-
-    #- provider: pypi
-    #- user: 4383
-    #- password:
-    #-   secure: "nR3B3hnD2idXB4bi4AphCbuEDtRfh0PeQtbKwM340FOqluIxMBp0tjlAAHKi1F7IaSIcZFM65tu5jbZiww6NuFPpG2JSRRMfDM0F9uvveay/ikr/5UQ74a9gK94nXoKaQLdB9fy6KvogL2ZkDIfhfwWxCHnyAeftstPGJH44Y3LXWKDyQNq/vXVPxqooMo4XIOMZmMvldjt7P9AE3DKadQnXzrH049XT00kruH0UIvKHej4IiPDOPhDpd9TZPti7yxWE795ZRuzUKw3PWsKvl0+cpZwFsrzOy5TLULQU2VY8SfPjmO29FAY4jL9qcmO/gQRd+E4RtIGMiB0cWQBYshx9sGKwTcFcm48YLHTJAPZZdj5HE21Wa4Womx3ZKJNjTaa7ymkf+511n8eHG9w4oEePgyzurqhIDUoeBYzkqfbsUbM+Q22+Rm0pwaGaUtWOBM6VxGl4F/3ci886uSggBDMoLas+KzV1sbU8RK+1Hn3M/bcINuFFAgxt48xKpG2dTOC8dfaW7ffaFyxM5y3/GGJ/WmsbGktB7Gzjl1d5Y8INt6dPAWYoWoSfdmqk8q9vsgnRnL/poaewDGAoDVvlxsfaz17apRzzWL4y9lr5VOcGSEsKbFEKJw05nq5zGSPuixJkoPw1KRAnCOm5UhBBB+rd1pmrnZncYAdl+59jFGc="
-    #- on:
-    #-   branch: devel
-    #- server: https://test.pypi.org/legacy/
-    #- distributions: sdist bdist_wheel

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@
 
 Get data from yaml file directly in your shell
 
+## Features
+- Extract values from json format
+- Extract values from yaml format
+- Automaticaly detect format (json/yaml)
+- Read data from file or pass data from stdin
+- Format output values
+
 ## Install or Update niet
 
 ```sh
@@ -18,6 +25,56 @@ $ pip install -U niet
 - Python 2.7+
 
 ## Usage
+
+### Help and options
+
+```shell
+$ niet --help
+usage: niet [-h] [-f {dquote,ifs,yaml,newline,json,squote}] object [file]
+
+Read data from YAML or JSON file
+
+positional arguments:
+  object                Path to object separated by dot (.). Use '.' to get
+                        whole file. eg: a.b.c
+  file                  Optional JSON or YAML filename. If not provided niet
+                        read from stdin
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -f {dquote,ifs,yaml,newline,json,squote}, --format {dquote,ifs,yaml,newline,json,squote}
+                        output format
+
+output formats:
+  dquote        Add double quotes to result
+  ifs   Return all elements of a list separated by IFS env var
+  yaml  Return object in YAML
+  newline       Return all element of a list in a new line
+  json  Return object in JSON
+  squote        Add single quotes to result
+```
+
+### With Json from stdin
+
+```shell
+$ echo '{"foo": "bar", "fizz": {"buzz": ["1", "2", "Fizz", "4", "Buzz"]}}' | niet fizz.buzz
+1
+2
+Fizz
+4
+Buzz
+$ echo '{"foo": "bar", "fizz": {"buzz": ["1", "2", "Fizz", "4", "Buzz"]}}' | niet fizz.buzz -f squote
+'1' '2''Fizz' '4' 'Buzz'
+$ echo '{"foo": "bar", "fizz": {"buzz": ["1", "2", "Fizz", "4", "Buzz"]}}' | niet . -f yaml
+fizz:
+  buzz:
+  - '1'
+  - '2'
+  - Fizz
+  - '4'
+  - Buzz
+foo: bar
+```
 
 ### With YAML file
 
@@ -41,14 +98,14 @@ wget https://gist.githubusercontent.com/4383/53e1599663b369f499aa28e27009f2cd/ra
 
 You can retrieve data from this file by using niet like this:
 ```sh
-$ niet /path/to/your/file.yaml ".project.meta.name"
+$ niet ".project.meta.name" /path/to/your/file.yaml
 my-project
-$ niet /path/to/your/file.yaml ".project.foo"
+$ niet ".project.foo" /path/to/your/file.yaml
 bar
-$ niet /path/to/your/file.yaml ".project.list-items"
+$ niet ".project.list-items" /path/to/your/file.yaml
 item1 item2 item3
 $ # assign return value to shell variable
-$ NAME=$(niet /path/to/your/file.yaml ".project.meta.name")
+$ NAME=$(niet ".project.meta.name" /path/to/your/file.yaml)
 $ echo $NAME
 my-project
 ```
@@ -79,14 +136,14 @@ wget https://gist.githubusercontent.com/4383/1bab8973474625de738f5f6471894322/ra
 
 You can retrieve data from this file by using niet like this:
 ```sh
-$ niet /path/to/your/file.json "project.meta.name"
+$ niet "project.meta.name" /path/to/your/file.json
 my-project
-$ niet /path/to/your/file.json "project.foo"
+$ niet "project.foo" /path/to/your/file.json
 bar
-$ niet /path/to/your/file.json "project.list-items"
+$ niet "project.list-items" /path/to/your/file.json
 item1 item2 item3
 $ # assign return value to shell variable
-$ NAME=$(niet /path/to/your/file.json "project.meta.name")
+$ NAME=$(niet "project.meta.name" /path/to/your/file.json)
 $ echo $NAME
 my-project
 ```
@@ -114,11 +171,11 @@ space otherwise.
 
 Examples (consider the previous [YAML file example](#with-yaml-file)):
 ```shell
-$ IFS="|" niet /path/to/your/file.yaml .project.list-items -f ifs
+$ IFS="|" niet .project.list-items /path/to/your/file.yaml -f ifs
 item1|item2|item3
-$ IFS=" " niet /path/to/your/file.yaml .project.list-items -f ifs
+$ IFS=" " niet .project.list-items /path/to/your/file.yaml -f ifs
 item1 item2 item3
-$ IFS="@" niet /path/to/your/file.yaml .project.list-items -f ifs
+$ IFS="@" niet .project.list-items /path/to/your/file.yaml -f ifs
 item1@item2@item3
 ```
 
@@ -127,7 +184,7 @@ but your content must, of course, don't contain IFS value:
 ```shell
 OIFS="$IFS"
 IFS="|"
-for i in $(niet /path/to/your/file.yaml .project.list-items -f ifs); do
+for i in $(niet .project.list-items /path/to/your/file.yaml -f ifs); do
     echo ${i}
 done
 IFS="${OIFS}"
@@ -149,10 +206,10 @@ All values are quoted with single quotes and are separated by IFS value.
 Examples (consider the previous [YAML file example](#with-yaml-file)):
 ```shell
 $ # With the default IFS
-$ niet /path/to/your/file.yaml .project.list-items -f squote
+$ niet .project.list-items /path/to/your/file.yaml -f squote
 'item1' 'item2' 'item3'
 $ # With a specified IFS
-$ IFS="|" niet /path/to/your/file.yaml .project.list-items -f squote
+$ IFS="|" niet .project.list-items /path/to/your/file.yaml -f squote
 'item1'|'item2'|'item3'
 ```
 
@@ -163,10 +220,10 @@ All values are quoted with a double quotes and are separated by IFS value.
 Examples (consider the previous [YAML file example](#with-yaml-file)):
 ```shell
 $ # With the default IFS
-$ niet /path/to/your/file.yaml .project.list-items -f dquote
+$ niet .project.list-items /path/to/your/file.yaml -f dquote
 'item1' 'item2' 'item3'
 $ # With a specified IFS
-$ IFS="|" niet /path/to/your/file.yaml .project.list-items -f dquote
+$ IFS="|" niet .project.list-items /path/to/your/file.yaml -f dquote
 "item1"|"item2"|"item3"
 ```
 
@@ -176,7 +233,7 @@ This format is usefull using shell while read loop. eg:
 ```sh
 while read value: do
     echo $value
-done < $(niet --format newline your-file.json project.list-items)
+done < $(niet --format newline project.list-items your-file.json)
 ```
  
 #### yaml
@@ -192,7 +249,7 @@ with return code `1`
 
 You can easily protect your script like this:
 ```sh
-PROJECT_NAME=$(niet your-file.yaml project.meta.name)
+PROJECT_NAME=$(niet project.meta.name your-file.yaml)
 if [ "$?" = "1" ]; then
     echo "Error occur ${PROJECT_NAME}"
 else
@@ -222,24 +279,59 @@ project:
 
 Retrieve the project name:
 ```sh
-$ niet tests/samples/sample.yaml project.meta.name
+$ niet project.meta.name tests/samples/sample.yaml
 my-project
 ```
 
 Deal with list of items
 ```sh
-$ for el in $(niet tests/samples/sample.yaml project.list-items); do echo ${el}; done
+$ for el in $(niet project.list-items tests/samples/sample.yaml); do echo ${el}; done
 item1
 item2
 item3
+```
+
+### Transform JSON to YAML
+
+With niet you can easily convert your JSON to YAML
+```shell
+$ niet . tests/samples/sample.json -f yaml
+project:
+  foo: bar
+  list-items:
+  - item1
+  - item2
+  - item3
+  meta:
+    name: my-project
+```
+
+### Transform YAML to JSON
+
+With niet you can easily convert your YAML to JSON
+```shell
+$ niet . tests/samples/sample.yaml -f json
+{
+    "project": {
+        "meta": {
+            "name": "my-project"
+        },
+        "foo": "bar",
+        "list-items": [
+            "item1",
+            "item2",
+            "item3"
+        ]
+    }
+}
 ```
 
 ## Tips
 
 You can pass your search with or without quotes like this:
 ```sh
-$ niet your-file.yaml project.meta.name
-$ niet your-file.yaml "project.meta.name"
+$ niet project.meta.name your-file.yaml
+$ niet "project.meta.name" your-file.yaml
 ```
 
 ## Contribute


### PR DESCRIPTION
Hi @dj4ngo!

This pull request introduce a new coolest feature for read data (json/yaml) directly from stdin or from a file.

Examples:
```shell
$ echo '{"foo": "bar", "fizz": {"buzz": ["1", "2", "Fizz", "4", "Buzz"]}}' | niet fizz.buzz
1
2
Fizz
4
Buzz
$ echo '{"foo": "bar", "fizz": {"buzz": ["1", "2", "Fizz", "4", "Buzz"]}}' | niet fizz.buzz -f squote
'1' '2''Fizz' '4' 'Buzz'
$ echo '{"foo": "bar", "fizz": {"buzz": ["1", "2", "Fizz", "4", "Buzz"]}}' | niet . -f yaml
fizz:
  buzz:
  - '1'
  - '2'
  - Fizz
  - '4'
  - Buzz
foo: bar
```

Now for reading from a file you need to pass the filename are the second positional argument:
```shell
$ niet . tests/samples/sample.yaml -f json
{
    "project": {
        "meta": {
            "name": "my-project"
        },
        "foo": "bar",
        "list-items": [
            "item1",
            "item2",
            "item3"
        ]
    }
}
```
The helping command now looks like this:
```shell
$ niet --help
usage: niet [-h] [-f {dquote,yaml,ifs,squote,newline,json}] object [file]

Read data from YAML or JSON file

positional arguments:
  object                Path to object separated by dot (.). Use '.' to get
                        whole file. eg: a.b.c
  file                  Optional JSON or YAML filename. If not provided niet
                        read from stdin

optional arguments:
  -h, --help            show this help message and exit
  -f {dquote,yaml,ifs,squote,newline,json}, --format {dquote,yaml,ifs,squote,newline,json}
                        output format

output formats:
  dquote        Add double quotes to result
  yaml  Return object in YAML
  ifs   Return all elements of a list separated by IFS env var
  squote        Add single quotes to result
  newline       Return all element of a list in a new line
  json  Return object in JSON
```

Also this pull request resolve an [exploitable vulnerability (CVE-2017-2809)](https://nvd.nist.gov/vuln/detail/CVE-2017-2809) due to the usage of `yaml.load` instead of `yaml.safe_load`

Examples of usages of this vulnerability:
```shell
$ echo '!!python/object/apply:os.system ["echo powned; uname -a"]' | niet . -f yaml
powned
Linux vm 4.8.0-54-generic #57~16.04.1-Ubuntu SMP Wed May 24 16:22:28 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
Invalid file. Only support valid json and yaml files
$ echo '!!python/object/apply:os.system ["echo powned; uname -a"]' > /tmp/powned.yaml
$ niet . /tmp/powned.yaml
powned
Linux vm 4.8.0-54-generic #57~16.04.1-Ubuntu SMP Wed May 24 16:22:28 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
Invalid file. Only support valid json and yaml input

```

Examples with the fix:
```shell
$ echo '!!python/object/apply:os.system ["echo powned; uname -a"]' | niet . -f yaml
Invalid code injection! :)
could not determine a constructor for the tag 'tag:yaml.org,2002:python/object/apply:os.system'
  in "<unicode string>", line 1, column 1:
    !!python/object/apply:os.system  ...
    ^
Invalid file. Only support valid json and yaml files
```

Fix #12