### PR TITLE
Remove duplicate actions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ before_install:
   - pip install -U setuptools
   - pip install -U wheel
 install:
-  - pip install tox-travis .[test]
-  - pip install bandit
+  - pip install tox-travis .[devel]
 script:
   - bandit -r niet
   - tox

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,9 +106,7 @@ create a virtual environment and install all the required dependencies:
 ```shell
 $ cd niet
 $ pipenv shell # pip install -U pipenv (if not installed)
-$ pip install -r requirements.txt
-$ pip install -r requirements_dev.txt
-$ python setup.py develop
+$ pip install -e .[devel]
 ```
 
 #### Make your changes

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,0 @@
-pbr
-tox
-fixtures
-bandit

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,10 +26,6 @@ packages =
     niet
 
 [extras]
-test =
-    fixtures
-    tox
-    bandit
 devel=
     fixtures
     pbr


### PR DESCRIPTION
Remove multiple requirements declarations format.
Prefer to use pip in editable mode (`pip install -e .[devel]`) instead of just use `python setup.py develop`.