### PR TITLE
get the niet version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ $ pip install -U niet
 
 ```shell
 $ niet --help
-usage: niet [-h] [-f {dquote,ifs,yaml,newline,json,squote}] object [file]
+usage: niet [-h] [-f {ifs,squote,newline,dquote,yaml,json}] [-s] [-v]
+            object [file]
 
 Read data from YAML or JSON file
 
@@ -42,16 +43,20 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
-  -f {dquote,ifs,yaml,newline,json,squote}, --format {dquote,ifs,yaml,newline,json,squote}
+  -f {ifs,squote,newline,dquote,yaml,json}, --format {ifs,squote,newline,dquote,yaml,json}
                         output format
+  -s, --silent          silent mode, doesn't display message when element was
+                        not found
+  -v, --version         print the Niet version number and exit (also
+                        --version)
 
 output formats:
-  dquote        Add double quotes to result
   ifs   Return all elements of a list separated by IFS env var
-  yaml  Return object in YAML
-  newline       Return all element of a list in a new line
-  json  Return object in JSON
   squote        Add single quotes to result
+  newline       Return all element of a list in a new line
+  dquote        Add double quotes to result
+  yaml  Return object in YAML
+  json  Return object in JSON
 ```
 
 ### With Json from stdin

--- a/niet/__init__.py
+++ b/niet/__init__.py
@@ -6,6 +6,8 @@ import sys
 
 from future.utils import viewitems
 
+import pkg_resources
+
 import yaml
 
 
@@ -106,6 +108,9 @@ def argparser():
     parser.add_argument('-s', '--silent', action='store_true',
                         help="silent mode, doesn't display message when \
                         element was not found")
+    parser.add_argument('-v', '--version', action='store_true',
+                        help="print the Niet version number and \
+                        exit (also --version)")
     return parser.parse_args()
 
 
@@ -168,8 +173,16 @@ def get_data(infile):
         return infile.read()
 
 
+def version():
+    installed = pkg_resources.get_distribution('niet').version
+    print("Niet version {}".format(installed))
+
+
 # Main
 def main():
+    if '-v' in sys.argv or '--version' in sys.argv:
+        version()
+        sys.exit(0)
     args = argparser()
     infile = args.file or sys.stdin
     search = args.object


### PR DESCRIPTION
Retrieve the niet version number via command line:
```shell
$ niet --version
Niet version <version>
$ niet -v
Niet version <version>
```
Fix #29 